### PR TITLE
missing semicolon

### DIFF
--- a/src/js/traffic.js
+++ b/src/js/traffic.js
@@ -654,7 +654,7 @@ var onMainDocHeadersReceived = function(details) {
 
     // Enforce strict HTTPS?
     if ( requestScheme === 'https' && µm.tMatrix.evaluateSwitchZ('https-strict', pageStats.pageHostname) ) {
-        csp += "default-src chrome-search: data: https: wss: 'unsafe-eval' 'unsafe-inline'";
+        csp += "default-src chrome-search: data: https: wss: 'unsafe-eval' 'unsafe-inline';";
     }
 
     // https://github.com/gorhill/httpswitchboard/issues/181


### PR DESCRIPTION
This apparently causes this:
[7491:7491:0110/224316:ERROR:CONSOLE(0)] "The Content Security Policy directive 'default-src' contains 'script-src' as a source expression. Did you mean 'default-src ...; script-src...' (note the semicolon)?", source: https://twitter.com/olgakay/with_replies (0)
[7491:7491:0110/224316:ERROR:CONSOLE(0)] "The source list for Content Security Policy directive 'default-src' contains an invalid source: ''none''. It will be ignored. Note that 'none' has no effect unless it is the only expression in the source list.", source: https://twitter.com/olgakay/with_replies (0)

Chromium Version 39.0.2171.95 (64-bit)

Also it appears to me that `stopPropagation` is in effect(is the javascript executed? even though I have `all` blocked - tested this) as I cannot do `Alt+D`(or `Ctrl+L`) to jump to address bar after the above page was loaded.

This fixes all that.