### PR TITLE
Add trailing newline to exported rules file

### DIFF
--- a/src/js/user-rules.js
+++ b/src/js/user-rules.js
@@ -198,7 +198,7 @@ var startImportFilePicker = function() {
 
 function exportUserRulesToFile() {
     vAPI.download({
-        'url': 'data:text/plain,' + encodeURIComponent(rulesFromHTML('#diff .left li')),
+        'url': 'data:text/plain,' + encodeURIComponent(rulesFromHTML('#diff .left li') + '\n'),
         'filename': uDom('[data-i18n="userRulesDefaultFileName"]').text()
     });
 }


### PR DESCRIPTION
According to POSIX a text file is "a file that contains characters
organized into zero or more lines" [1] and a line is "a sequence of zero
or more non- <newline> characters plus a terminating <newline>
character" [2].  Since we are claiming to produce a text file, it should
have a trailing newline.

[1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_397
[2] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206