### PR TITLE
Fixed chrome os x issue with too small popup size (fixes #423)

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -90,6 +90,8 @@
     <span data-i18n="matrix1stPartyLabel"></span>
 </div>
 
+<div style="clear: both; height: 0px;"></div>
+
 <script src="lib/punycode.js"></script>
 <script src="js/vapi-common.js"></script>
 <script src="js/vapi-client.js"></script>


### PR DESCRIPTION
The clear div makes it easier for browsers to detect the size of the initially invisible divs.

This solves the issue described in #423 