### PR TITLE
Allow horizontal scrolling.

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -7,7 +7,7 @@ body {
     min-height: 16em;
     min-width: 32em;
     opacity: 1;
-    overflow-x: hidden;
+    overflow-x: auto;
     overflow-y: auto;
     padding: 0;
     }
@@ -24,7 +24,6 @@ a {
     left:0;
     padding: 0;
     position: fixed;
-    right: 0;
     top: 0;
     z-index: 10;
     }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -960,6 +960,11 @@ var makeMenu = function() {
         document.querySelector('.paneHead').clientHeight + 'px'
     );
 
+    // Make the header scroll with the window.
+    window.onscroll = function () {
+        document.querySelector('.paneHead').style.left = "-" + window.scrollX + "px";
+    };
+
     startMatrixUpdate();
     makeMatrixGroup0(groupStats[0]);
     makeMatrixGroup1(groupStats[1]);


### PR DESCRIPTION
Provide a horizontal scrollbar when required, and scroll the
menu header correctly while keeping it fixed vertically.

This allows Chromium users with a `Page zoom` setting to be able to see
the whole matrix.

Closes #440.

Tested only in Chromium 47.0.2526.73 (64-bit) on Arch Linux.