### PR TITLE
Adding visual cue indicating that a temp rule will be deleted if clicked

### DIFF
--- a/src/css/user-rules.css
+++ b/src/css/user-rules.css
@@ -128,6 +128,9 @@ body[dir="rtl"] #commitButton:before {
 #diff .right li.notLeft {
     color: #000;
     }
+#diff .right li.notLeft:hover {
+    text-decoration: line-through;
+    }
 #diff .right li.notRight {
     color: #000;
     }


### PR DESCRIPTION
When clicking a temporary rule that is not in the permanent list, it is
deleted, yet no visual cue indicates this is the intended behaviour. I
initially thought it would commit the line to the permanent rules.

This patch adds a line-through on :hover to signal it.