### PR TITLE
Better colouring in CSS.

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -23,6 +23,7 @@ body {
     width: 100vw;
     height: 50px;
     z-index: 10;
+    background-color: white;
     }
 #dashboard-nav-widgets {
     margin: 0;
@@ -34,6 +35,7 @@ body {
 #dashboard-nav-widgets span {
     padding: 0 0.5em;
     font-size: larger;
+    color: black;
     }
 .tabButton {
     margin: 0;


### PR DESCRIPTION
Very minor, but if users set their own colour font and background colours in about:preferences#content, the dashboard will look strange. Only tested with Firefox.

![dashboard](https://cloud.githubusercontent.com/assets/7316177/13197872/de503e4c-d7fa-11e5-9dee-c3c572e7251c.png)

In Firefox
- go to about:preferences#content
- change colours for text (not black) and background (not white) and not to use system colours
- have a look at uMatrix's dashboard and the <span>uMatrix</span> will not be black and there will be a not white line under the tabs
