### PR TITLE
Handle small screens

### DIFF
--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -2221,7 +2221,7 @@ vAPI.toolbarButton = {
             }
 
             var height;
-            if(window.screen.availHeight && window.screen.availHeight <= 800) {
+            if(window.screen && window.screen.availHeight && window.screen.availHeight <= 800) {
                 // We set a smaller limit for height
                 height = Math.min(body.clientHeight, 300);
             } else {

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -2220,8 +2220,14 @@ vAPI.toolbarButton = {
                 return;
             }
 
-            // We set a limit for height
-            var height = Math.min(body.clientHeight, 600);
+            var height;
+            if(window.screen.availHeight && window.screen.availHeight <= 800) {
+                // We set a smaller limit for height
+                height = Math.min(body.clientHeight, 300);
+            } else {
+                // We set a limit for height
+                height = Math.min(body.clientHeight, 600);
+            }
 
             // https://github.com/chrisaljoudi/uBlock/issues/730
             // Voodoo programming: this recipe works


### PR DESCRIPTION
As reported in #483 the popup can become to large for the screen.
I added a check to see if the [Screen.availHeight](https://developer.mozilla.org/en-US/docs/Web/API/Screen/availHeight) is smaller than 800 and if so set the maximum to 300px.

After many different approaches this was the only one which worked for me.

This is only a fix for Firefox and I don't know if this issue occurs when using chrome. 

I hope you find it useful.
Regards
# Screenshots

I packed and tested it on Firefox.
## 640x480

![640x480](https://cloud.githubusercontent.com/assets/5737978/16041940/7ddd4f58-3238-11e6-8e67-7f5fab6c02c3.png)
## 800x600

![800x600](https://cloud.githubusercontent.com/assets/5737978/16041941/820d000a-3238-11e6-9c20-8159b5033834.png)
## 1080x750

![1080x750](https://cloud.githubusercontent.com/assets/5737978/16041944/855e8e4a-3238-11e6-82bb-93f62377c7c7.png)
## 1280x920

![1280x920](https://cloud.githubusercontent.com/assets/5737978/16041947/878e002e-3238-11e6-9101-a288a88502f5.png)
# Steps to reproduce
- Firefox 47.0
- Screen resolution 800x600 (or similar height)
- Go on youtube.com
- Disable all filters
- The matrix will grow bigger than the screen and the bottom most items won't be accessible.
