### PR TITLE
Allow JSON files as import from Noscript

### DIFF
--- a/src/js/user-rules.js
+++ b/src/js/user-rules.js
@@ -179,7 +179,7 @@ var handleImportFilePicker = function() {
     if ( file === undefined || file.name === '' ) {
         return;
     }
-    if ( file.type.indexOf('text') !== 0 ) {
+    if ( file.type.indexOf('text') !== 0 && file.type !== 'application/json') {
         return;
     }
     var fr = new FileReader();


### PR DESCRIPTION
After trying to reproduce the issue #552 I wasn't able to import the noscript settings too. 
I saved the file as `noscript.json` (because it really is a json file) and tried to import it.
It didn't work and after some debugging I saw that the check 
```js
file.type.indexOf('text')
```
failed because the type was `application/json`.

The best way to handle this in my opinion would be to either allow `application/json` type or disable this check.
I hope you find this useful.
Regards
