### PR TITLE
Added black default color for popup buttons

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -104,6 +104,7 @@ body .toolbar button {
     padding: 4px;
     font: inherit;
     background-color: white;
+    color: black;
     opacity: 0.9;
     cursor: pointer;
     vertical-align: top;


### PR DESCRIPTION
On Linux Firefox with dark GTK theme, the three rightmost toolbar icons of the popup can be light gray, or even white some time, this fixes this issue.