### PR TITLE
Correct check for undefined variable

### DIFF
--- a/src/js/user-rules.js
+++ b/src/js/user-rules.js
@@ -126,7 +126,7 @@ var fromNoScript = function(content) {
         noscript === null ||
         typeof noscript !== 'object' ||
         typeof noscript.prefs !== 'object' ||
-        typeof noscript.prefs.clearClick === undefined ||
+        typeof noscript.prefs.clearClick === 'undefined' ||
         typeof noscript.whitelist !== 'string' ||
         typeof noscript.V !== 'string'
     ) {


### PR DESCRIPTION
The code was comparing the result of `typeof` with a variable named `undefined`

As typeof returns a string it should compare to `'undefined'`