### PR TITLE
My Rules: "Display changes inline" checkbox

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -453,6 +453,10 @@
         "message": "my-umatrix-rules.txt",
         "description": "default file name to use"
     },
+    "userRulesDisplayChangesInlineCheckbox": {
+        "message": "Display changes inline",
+        "description": "Toggle whether changed rules rows are inline, instead of grouped together"
+    },
 
 
     "hostsFilesPrompt" : {

--- a/src/css/user-rules.css
+++ b/src/css/user-rules.css
@@ -105,6 +105,10 @@ body[dir="rtl"] #commitButton:before {
 #diff .left {
     padding: 0 0 0 0;
     }
+#diff .left input,
+#diff .left label {
+    visibility: hidden;
+}
 #diff .right > ul {
     color: #888;
     }

--- a/src/js/user-rules.js
+++ b/src/js/user-rules.js
@@ -47,13 +47,16 @@ var directiveSort = function(a, b) {
 /******************************************************************************/
 
 var processUserRules = function(response) {
-    var rules, rule, i;
+    var rules, rule, i, inlineDiff;
     var permanentList = [];
     var temporaryList = [];
+    var bothList = [];
     var allRules = {};
     var permanentRules = {};
     var temporaryRules = {};
     var onLeft, onRight;
+
+    inlineDiff = uDom('#displayChangesInlineCheckbox').prop('checked');
 
     rules = response.permanentRules.split(/\n+/);
     i = rules.length;
@@ -77,8 +80,12 @@ var processUserRules = function(response) {
         onLeft = permanentRules.hasOwnProperty(rule);
         onRight = temporaryRules.hasOwnProperty(rule);
         if ( onLeft && onRight ) {
-            permanentList.push('<li>', rule);
-            temporaryList.push('<li>', rule);
+            if ( inlineDiff ) {
+                permanentList.push('<li>', rule);
+                temporaryList.push('<li>', rule);
+            } else {
+                bothList.push('<li>', rule);
+            }
         } else if ( onLeft ) {
             permanentList.push('<li>', rule);
             temporaryList.push('<li class="notRight toRemove">', rule);
@@ -86,6 +93,10 @@ var processUserRules = function(response) {
             permanentList.push('<li>&nbsp;');
             temporaryList.push('<li class="notLeft">', rule);
         }
+    }
+    if ( !inlineDiff ) {
+        Array.prototype.push.apply(permanentList, bothList);
+        Array.prototype.push.apply(temporaryList, bothList);
     }
 
     // TODO: build incrementally.
@@ -273,6 +284,12 @@ var editCancelHandler = function(ev) {
 
 /******************************************************************************/
 
+var toggleInlineDiff = function(ev) {
+    messager.send({ what: 'getUserRules' }, processUserRules);
+};
+
+/******************************************************************************/
+
 var temporaryRulesToggler = function(ev) {
     var li = uDom(this);
     li.toggleClass('toRemove');
@@ -315,6 +332,7 @@ uDom.onLoad(function() {
     uDom('#editEnterButton').on('click', editStartHandler);
     uDom('#editStopButton').on('click', editStopHandler);
     uDom('#editCancelButton').on('click', editCancelHandler);
+    uDom('#displayChangesInlineCheckbox').on('change', toggleInlineDiff);
     uDom('#diff > .right > ul').on('click', 'li', temporaryRulesToggler);
 
     messager.send({ what: 'getUserRules' }, processUserRules);

--- a/src/user-rules.html
+++ b/src/user-rules.html
@@ -21,6 +21,9 @@
             <button type="button" id="exportButton" data-i18n="userRulesExport"></button>
             <button type="button" id="revertButton" data-i18n="userRulesRevert"></button>
             </div>
+        <!-- Invisible checkbox and label for vertical alignment -->
+        <input type="checkbox">
+        <label></label>
         <ul></ul>
         </div>
     <div class="pane right">
@@ -32,6 +35,8 @@
             <button type="button" id="editCancelButton" data-i18n="userRulesEditDicard"></button>
             <button type="button" id="importButton" data-i18n="userRulesImport"></button>
             </div>
+        <input type="checkbox" id="displayChangesInlineCheckbox" checked="checked">
+        <label data-i18n="userRulesDisplayChangesInlineCheckbox" for="displayChangesInlineCheckbox"></label>
         <textarea spellcheck="false"></textarea>
         <ul></ul>
         </div>


### PR DESCRIPTION
Fixes #636 

**Checked (inline, default):**

<img width="935" alt="screen shot 2016-10-08 at 11 49 18 am" src="https://cloud.githubusercontent.com/assets/87961/19215241/729a0ef4-8d4d-11e6-8b54-89fda87cff67.png">

**Unchecked (grouped changes at top):**

<img width="940" alt="screen shot 2016-10-08 at 11 49 34 am" src="https://cloud.githubusercontent.com/assets/87961/19215246/88f5f4ce-8d4d-11e6-950f-561255a97f0f.png">
