### PR TITLE
Update legacy-toolbar-buttons.css and /img/browsericons/ icons (palemoon)

### DIFF
--- a/platform/firefox/css/legacy-toolbar-button.css
+++ b/platform/firefox/css/legacy-toolbar-button.css
@@ -16,8 +16,8 @@ toolbar[iconsize="small"] #umatrix-legacy-button.off {
     color: #fff;
     content: attr(badge);
     font: bold 10px sans-serif;
-    margin-top: -2px;
-    padding: 0 2px;
+    margin-top: 1px;
+    padding: -1px;
     position: fixed;
 }
 /* This hack required because if the before content changes it de-pops the


### PR DESCRIPTION
This small change fixs a little issue with the palemoon browser' s toolbars, which become a bit too high when you put the uMatrix button on the toolbars.

These changes, coupled with the reduction  of the icons placed in /img/browsericons/ from 19px to 16px, fixs  the problem for me.