### PR TITLE
Workaround Firefox bug 1324499

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -621,3 +621,17 @@ body.colorblind .rw .matCell.t2 #blacklist:hover {
 #domainOnly:hover {
     opacity: 1;
     }
+
+@-moz-document url-prefix() {
+    html {
+        overflow-y: hidden;
+        }
+    .paneContainer {
+        max-height: 600px;
+        overflow-x: hidden;
+        overflow-y: scroll;
+        }
+    .paneHead {
+        right: auto;
+        }
+    }

--- a/src/popup.html
+++ b/src/popup.html
@@ -17,6 +17,7 @@
     <div id="cellHotspots"><div id="whitelist"></div><div id="blacklist"></div><div id="domainOnly"><span class="fa"></span></div></div>
 </div>
 
+<div class="paneContainer">
 <div class="paneHead">
     <a id="gotoDashboard" class="extensionURL" href="#" data-extension-url="dashboard.html" title="popupTipDashboard">uMatrix <span id="version"> </span><span class="fa">&#xf013;</span></a>
     <div id="toolbarContainer">
@@ -83,7 +84,7 @@
     </div>
     <div id="noNetTrafficPrompt" style="display:none;text-align:center;font-size:large"></div>
 </div>
-
+</div>
 <!-- Convenient to auto-fetch locale strings used in scripts -->
 <div style="display: none;">
     <span data-i18n="matrixBlacklistedHostnames"></span>


### PR DESCRIPTION
See [Bugzilla #1324499](https://bugzilla.mozilla.org/show_bug.cgi?id=1324499).

Only the scroll of the root HTML frame is reset, so if we have a `div` wrapping everything and keeping the root frame from scrolling, then the bug is avoided.