### PR TITLE
Use native textarea when editing user rules

### DIFF
--- a/src/css/user-rules.css
+++ b/src/css/user-rules.css
@@ -139,7 +139,6 @@ body[dir="rtl"] #commitButton:before {
     text-decoration: line-through;
     }
 #diff textarea {
-    background-color: #f8f8ff;
     border: 0;
     border-top: 1px solid #eee;
     direction: ltr;


### PR DESCRIPTION
Use native textarea (no color set) when editing temporary user rules.
Improves visibility significantly when eg. using Firefox with a dark GTK theme.
Also, it is consistent with other text fields, as they're also drawn using the native colors.

Tested only using the "Inspect Element" feature in Firefox to change the CSS temporarily.

Before: ![Before](https://user-images.githubusercontent.com/1196130/31521133-aeec18ec-afa8-11e7-9986-04a451ff0f2a.png)

After: ![After](https://user-images.githubusercontent.com/1196130/31521144-b3cb4b4e-afa8-11e7-96eb-9d36f977924a.png)

