### PR TITLE
add [optional] "close and reload" button

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -707,5 +707,18 @@
     "errorCantConnectTo":{
         "message":"Network error: Unable to connect to {{url}}",
         "description":""
+    },
+
+    "settingsShowApplyButton":{
+        "message":"Show 'Apply Changes' button in popup",
+        "description": "English: Show 'Apply Changes' button in popup"
+    },
+    "buttonApplyChanges":{
+        "message":"Apply Changes",
+        "description":"English: Apply Changes"
+    },
+    "buttonApplyChangesTip" : {
+        "message": "Close uMatrix popup and reload current tab",
+        "description": "English: Close uMatrix popup and reload current tab"
     }
 }

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -80,6 +80,9 @@ body[dir="ltr"] .tip-anchor-right[data-i18n-tip]:hover:after,
 body[dir="rtl"] .tip-anchor-left[data-i18n-tip]:hover:after {
     right: -3vw;
     }
+.tip-anchor-above[data-i18n-tip]:hover:after {
+    top: -100%;
+    }
 button.custom {
     padding: 0.6em 1em;
     border: 1px solid transparent;

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -621,3 +621,19 @@ body.colorblind .rw .matCell.t2 #blacklist:hover {
 #domainOnly:hover {
     opacity: 1;
     }
+
+#buttonApplyChanges {
+    background-color: #eee;
+    color: #333;
+    font-weight: bold;
+    margin: 2.5em 2.5% .5em;
+    opacity: .9;
+    padding: .5em;
+    width: 95%;
+    }
+
+#buttonApplyChanges:hover {
+    background-color: #6c6;
+    color: #000;
+    opacity: 1;
+    }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -120,6 +120,7 @@ return {
         popupScopeLevel: 'domain',
         processHyperlinkAuditing: true,
         processReferer: false,
+        showApplyButton: true,
         spoofUserAgent: false,
         spoofUserAgentEvery: 5,
         spoofUserAgentWith: defaultUserAgentStrings

--- a/src/js/messaging.js
+++ b/src/js/messaging.js
@@ -166,6 +166,7 @@ var matrixSnapshot = function(pageStore, details) {
         url: pageStore.pageUrl,
         userSettings: {
             colorBlindFriendly: µmuser.colorBlindFriendly,
+            showApplyButton: µmuser.showApplyButton,
             displayTextSize: µmuser.displayTextSize,
             popupScopeLevel: µmuser.popupScopeLevel
         }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1020,6 +1020,7 @@ var makeMenu = function() {
 function initMenuEnvironment() {
     uDom('body').css('font-size', getUserSetting('displayTextSize'));
     uDom('body').toggleClass('colorblind', getUserSetting('colorBlindFriendly') === true);
+    uDom('#buttonApplyChanges').css('display', getUserSetting('showApplyButton') === true ? 'inline-block' : 'none');
     uDom('#version').text(matrixSnapshot.appVersion || '');
 
     var prettyNames = matrixHeaderPrettyNames;
@@ -1203,6 +1204,11 @@ function buttonReloadHandler(ev) {
         tabId: matrixSnapshot.tabId,
         bypassCache: ev.shiftKey
     });
+}
+
+function buttonApplyChangesHandler(ev) {
+    buttonReloadHandler(ev);
+    vAPI.closePopup();
 }
 
 /******************************************************************************/
@@ -1440,6 +1446,8 @@ uDom('#matList').on('click', '.g4Meta', function() {
     setUISetting('popupHideBlacklisted', collapsed);
     resizePopup();
 });
+
+uDom('#buttonApplyChanges').on('click', buttonApplyChangesHandler);
 
 resizePopup();
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -90,6 +90,11 @@
     <span data-i18n="matrix1stPartyLabel"></span>
 </div>
 
+<div class="bottom" style="clear:both; width:100%">
+    <button id="buttonApplyChanges" type="button" class="tip-anchor-right tip-anchor-above"
+     data-i18n="buttonApplyChanges" data-i18n-tip="buttonApplyChangesTip"></button>
+</div>
+
 <div style="clear: both; height: 0px;"></div>
 
 <script src="lib/punycode.js"></script>

--- a/src/settings.html
+++ b/src/settings.html
@@ -47,6 +47,9 @@ ul > li {
     <li>
         <input id="cloudStorageEnabled" type="checkbox" data-range="bool">
         <label data-i18n="settingsCloudStorageEnabled" for="cloudStorageEnabled"></label>
+    <li>
+        <input id="showApplyButton" type="checkbox" data-range="bool">
+        <label data-i18n="settingsShowApplyButton" for="showApplyButton"></label>
 </ul>
 
 


### PR DESCRIPTION
Rather than trying to automagically reload tabs when the user clicks away from the popup (#813), this PR simply adds a more obvious `Apply Changes` button along the bottom that both reloads the tab AND closes the popup window in one fell swoop.

Also, for users who might find this change too ostentatious, I've gone ahead and added a `Show 'Apply Changes' button in popup` checkbox in the settings, as well, allowing them turn it back off.

PS — I wasn't sure of the best way to handle localization: whether I should add [default] English versions for each language, whether I should add my own "best guess" translations, or whether I should leave that for the crowdin.com project.  Let me know, and I'd be happy to push another commit...

PPS — This PR solves a similar problem to #814, but doesn't require *saving* temporary changes.