### PR TITLE
Fix noscript spoof setting not being saved on change

### DIFF
--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -106,6 +106,7 @@ function onInputChanged(ev) {
         changeUserSettings(target.id, target.checked);
         break;
     case 'noMixedContent':
+    case 'noscriptTagsSpoofed':
     case 'processReferer':
         changeMatrixSwitch(
             target.getAttribute('data-matrix-switch'),


### PR DESCRIPTION
Seems `settings.js` was refactored a little and this setting was missed from the list, resulting in it not being saved when the checkbox was changed.