### PR TITLE
Update hyperlink auditing HTML spec url

### DIFF
--- a/src/js/traffic.js
+++ b/src/js/traffic.js
@@ -194,7 +194,7 @@ var onBeforeSendHeadersHandler = function(details) {
     // in request log. This way the user is better informed of what went
     // on.
 
-    // https://html.spec.whatwg.org/multipage/semantics.html#hyperlink-auditing
+    // https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing
     //
     // Target URL = the href of the link
     // Doc URL = URL of the document containing the target URL


### PR DESCRIPTION
The section regarding hyperlink auditing has been moved to another url. I've updated it on a comment of yours.
I didn't touch the localization json files (`privacyProcessHyperlinkAuditingPrompt` key), since I believe you handle those yourself using Crowdin.