### PR TITLE
Update Permissions with the correct link

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -558,7 +558,7 @@
         "description": ""
     },
     "aboutPermissions" : {
-        "message": "<a href='https://github.com/gorhill/httpswitchboard/wiki/Permissions'>Permissions</a>",
+        "message": "<a href='https://github.com/gorhill/uMatrix/wiki/Permissions'>Permissions</a>",
         "description": ""
     },
     "aboutCode" : {


### PR DESCRIPTION
Replaces `httpswitchboard` with `uMatrix` in the URL and you may need to do that for all the rest of the locales as this's one for `en`