### PR TITLE
Update someonewhocares.org to use HTTPS

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -40,10 +40,10 @@
 		"updateAfter": 11,
 		"title": "Dan Pollock’s hosts file",
 		"contentURL": [
-			"http://someonewhocares.org/hosts/hosts",
+			"https://someonewhocares.org/hosts/hosts",
 			"assets/thirdparties/someonewhocares.org/hosts/hosts.txt"
 		],
-		"supportURL": "http://someonewhocares.org/hosts/"
+		"supportURL": "https://someonewhocares.org/hosts/"
 	},
 	"hphosts": {
 		"content": "filters",


### PR DESCRIPTION
http requests to someonewhocares.org now responds with 302 redirects to the secure version - so just use the https version to start with