### PR TITLE
Show placeholder for blocked `frame` elements

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -124,6 +124,7 @@ var collapser = (function() {
         reURLPlaceholder = /\{\{url\}\}/g;
     var src1stProps = {
         'embed': 'src',
+        'frame': 'src',
         'iframe': 'src',
         'img': 'src',
         'object': 'data'
@@ -133,6 +134,7 @@ var collapser = (function() {
     };
     var tagToTypeMap = {
         embed: 'media',
+        frame: 'frame',
         iframe: 'frame',
         img: 'image',
         object: 'media'
@@ -187,6 +189,7 @@ var collapser = (function() {
                 continue;
             }
             switch ( tag ) {
+            case 'frame':
             case 'iframe':
                 if ( placeholders.frame !== true ) { break; }
                 let docurl =
@@ -321,11 +324,11 @@ var collapser = (function() {
         while ( i-- ) {
             node = nodeList[i];
             if ( node.nodeType !== 1 ) { continue; }
-            if ( node.localName === 'iframe' ) {
+            if ( node.localName === 'iframe' || node.localName === 'frame' ) {
                 addIFrame(node);
             }
             if ( node.childElementCount !== 0 ) {
-                addIFrames(node.querySelectorAll('iframe'));
+                addIFrames(node.querySelectorAll('iframe, frame'));
             }
         }
     };
@@ -456,7 +459,7 @@ var collapser = (function() {
     }
 
     collapser.addMany(document.querySelectorAll('img'));
-    collapser.addIFrames(document.querySelectorAll('iframe'));
+    collapser.addIFrames(document.querySelectorAll('iframe, frame'));
     collapser.process();
 })();
 


### PR DESCRIPTION
A fairly simple change, this PR enables the iframe placeholder code to run for blocked [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) elements. It previously only ran on blocked [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) elements.

Before:
![frame-before](https://user-images.githubusercontent.com/22776566/55680883-3c25c300-590f-11e9-9558-f372b10bea0c.png)

After:
![frame-after](https://user-images.githubusercontent.com/22776566/55680886-421ba400-590f-11e9-9212-2b6344cf6081.png)

Example site: http://spth.de/
As reported in https://github.com/uBlockOrigin/uMatrix-issues/issues/120.