### PR TITLE
Minor fixes

### DIFF
--- a/src/css/fa-icons.css
+++ b/src/css/fa-icons.css
@@ -40,6 +40,9 @@
 .fa-icon.disabled > .fa-icon-badge {
     display: none;
     }
+.fa-icon.fa-icon-vflipped {
+    transform: scale(1, -1);
+    }
 
 .fa-icon > svg {
     height: 1em;

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -347,10 +347,10 @@ body.tabless .needtab {
     text-align: left;
     }
 .matRow {
-    align-items: flex-start;
     display: flex;
     }
 .matCell {
+    align-items: center;
     box-sizing: content-box;
     display: inline-flex;
     flex-shrink: 0;
@@ -374,6 +374,7 @@ body.tabless .needtab {
     font-weight: 100;
     }
 .paneContent .matrix .matRow > .matCell:first-child > b {
+    display: contents;
     font-weight: normal;
     }
 
@@ -383,9 +384,10 @@ body.tabless .needtab {
     flex-grow: 1;
     flex-shrink: 1;
     justify-content: flex-end;
+    text-align: right;
     unicode-bidi: embed;
     width: 16em;
-    word-break: keep-all;
+    word-break: break-all;
     }
 .matrix .matGroup.g4 .matRow.ro > .matCell:first-child {
     direction: inherit;

--- a/src/hosts-files.html
+++ b/src/hosts-files.html
@@ -55,7 +55,7 @@
          --><a class="fa-icon mustread" href="" target="_blank">info-circle</a>&#8203;<!--
          --><span class="fa-icon status unsecure" title="http">unlock</span>&#8203;<!--
          --><span class="counts dim status"></span>&#8203;<!--
-         --><span class="fa-icon status obsolete" title="hostsFilesExternalListObsolete">exclamation-triangle</span>&#8203;<!--
+         --><span class="fa-icon status obsolete" data-i18n-title="hostsFilesExternalListObsolete">exclamation-triangle</span>&#8203;<!--
          --><span class="fa-icon status cache">clock</span>&#8203;<!--
          --><span class="fa-icon status updating">spinner</span>&#8203;<!--
          --><span class="fa-icon status failed">unlink</span>

--- a/src/js/matrix.js
+++ b/src/js/matrix.js
@@ -388,7 +388,9 @@ Matrix.prototype.evaluateCellZ = function(srcHostname, desHostname, type) {
     // srcHostname is '*' at this point
 
     // Preset blacklisted hostnames are blacklisted in global scope
-    if ( type === '*' && µm.ubiquitousBlacklistRef.matches(desHostname) !== -1 ) {
+    // https://github.com/uBlockOrigin/uMatrix-issues/issues/284
+    //   Only consider hostname blocklisted if it's a full match.
+    if ( type === '*' && µm.ubiquitousBlacklistRef.matches(desHostname) === 0 ) {
         return 1;
     }
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1327,6 +1327,7 @@ const gotoExtensionURL = function(ev) {
         what: 'gotoExtensionURL',
         url,
         select: true,
+        index: -1,
         shiftKey: ev.shiftKey,
     });
     dropDownMenuHide();

--- a/tools/make-chromium.sh
+++ b/tools/make-chromium.sh
@@ -19,7 +19,7 @@ cp    ./platform/chromium/manifest.json $DES/
 cp    LICENSE.txt                       $DES/
 
 echo "*** uMatrix.chromium: Generating meta..."
-python tools/make-chromium-meta.py $DES/
+python3 tools/make-chromium-meta.py $DES/
 
 if [ "$1" = all ]; then
     echo "*** uMatrix.chromium: Creating package..."

--- a/tools/make-firefox.sh
+++ b/tools/make-firefox.sh
@@ -21,7 +21,7 @@ cp    platform/firefox/*.js                 $DES/js/
 cp    platform/firefox/manifest.json        $DES/
 
 echo "*** uMatrix.firefox: Generating meta..."
-python tools/make-firefox-meta.py           $DES/
+python3 tools/make-firefox-meta.py          $DES/
 
 if [ "$1" = all ]; then
     echo "*** uMatrix.firefox: Creating package..."

--- a/tools/make-opera.sh
+++ b/tools/make-opera.sh
@@ -34,6 +34,6 @@ cp -R ./src/_locales/tr    $DES/_locales/
 cp -R ./src/_locales/zh_TW $DES/_locales/
 
 echo "*** uMatrix.opera: Generating meta..."
-python tools/make-opera-meta.py         $DES/
+python3 tools/make-opera-meta.py        $DES/
 
 echo "*** uMatrix.opera: Package done."


### PR DESCRIPTION
Another lot of small fixes for things I've noticed. As always, if some aren't wanted just let me know and I'll drop it from the pull request.

* Fix display of subdomains of blocklisted domains (https://github.com/uBlockOrigin/uMatrix-issues/issues/284)
* Call `python3` rather than `python` in build scripts, to allow building without Python 2 installed (the scripts include a `python3` shebang line already, so not a major change)
* Open logger/dashboard links adjacent to current tab (I included this in [my last lot of fixes](https://github.com/gorhill/uMatrix/pull/1005), but changes in https://github.com/gorhill/uMatrix/commit/9b29230 undid it)
* Add missing `.fa-icon-vflipped` CSS, to fix search arrow in asset viewer
* Fix the tooltip of the "obsolete" icon on the assets dashboard page
* Allow line breaks for long domains in the popup panel, so the full domain can be seen (tested on http://www.thelongestdomainnameintheworldandthensomeandthensomemoreandmore.com/):
Before: 
![no line breaks](https://user-images.githubusercontent.com/22776566/90260511-1ed60280-de3b-11ea-9e88-6723460da5d6.png)
After: 
![line breaks](https://user-images.githubusercontent.com/22776566/90260551-2b5a5b00-de3b-11ea-94d1-5f80f6f6e69c.png)